### PR TITLE
Align archived chats with Harness rc.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ dsh plugin --profile web add dsh-archived-chats
 
 Restart DSH once after installing, then open **Settings → Archived Chats**.
 
+## Compatibility
+
+Version 0.5.1 is tested against DeepSeek Harness `0.1.0-rc.7`. The plugin registers a top-level `settings.section`, so the rc.7 keyed-slot change for `settings.plugin.item` does not apply to it. Future Harness releases should still be checked with the smoke suite and a real-host UI pass before publishing a plugin update, because client slot and design-token contracts may evolve.
+
 ## Features
 
 - **Complete archived-session list**, grouped by workspace (project) with a per-group count. Every group can be collapsed or expanded, and the state is remembered per browser.
@@ -30,7 +34,7 @@ Restart DSH once after installing, then open **Settings → Archived Chats**.
 - **In-place live deletion**: deleting a resident session replays the agent factory's own disposer sequence — `cancel({ kind: 'disposed' })` → `whenIdle` → `flush` → `agent.scope.dispose()` → detach of the `agents` and `sessions` store entries. The session detach emits `session/disposed`, the persistence coordinator retires (drains and releases) the write path, and the ordinary cold delete completes in the same request. The store entries are internal surfaces, so every step is feature-detected; anything missing falls back to park-and-defer.
 - **Pending-deletion store** (fallback path and crash bracket): the id is recorded in `$DSH_HOME/plugin-data/archived-chats/pending-deletions.json` while the session stays archived and hidden; the next boot sweeps the queue through the ordinary delete path. In-place deletes are bracketed by the same store (recorded before disposal, cleared once the files are gone), so a crash mid-delete is completed on the next start. Parked sessions are excluded from the listing; unarchiving cancels a pending deletion.
 - **Title cache**: resolved titles are memoized per id across list refreshes instead of re-reading every archived log; delete and unarchive invalidate their entries.
-- **Browser half** (`lib/client.js`) registers a `settings.section` slot entry (order 30) and renders the page with React and DSH design tokens.
+- **Browser half** (`lib/client.js`) registers a `settings.section` slot entry (order 30) and renders the page with React and the rc.7 DSH overlay/state design tokens.
 
 ## Development
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,6 +14,10 @@ dsh plugin --profile web add dsh-archived-chats
 
 安装后重启一次 DSH，然后打开 **设置 → 已归档的聊天**。
 
+## 兼容性
+
+0.5.1 版本以 DeepSeek Harness `0.1.0-rc.7` 为验证基线。插件注册的是顶层 `settings.section`，因此 rc.7 针对 `settings.plugin.item` 的 keyed-slot 变更不影响本插件。以后 Harness 发布新版本时，仍应在发布插件更新前重跑冒烟测试并检查真实宿主页面，因为客户端插槽和设计令牌契约仍可能演进。
+
 ## 功能
 
 - **完整归档列表**：按工作区（项目）分组并显示每组数量；每个分组都可折叠/展开，状态按浏览器记忆。
@@ -30,7 +34,7 @@ dsh plugin --profile web add dsh-archived-chats
 - **活会话原地删除**：删除仍驻留后台的会话时，插件复刻 agent 工厂自身 disposer 的顺序——`cancel({ kind: 'disposed' })` → `whenIdle` → `flush` → `agent.scope.dispose()` → 依次 detach `agents` 与 `sessions` 两个 store 条目；session detach 发出 `session/disposed`，持久化协调器随之 retire（排空并释放）该会话的写入通道，之后冷删除路径在同一请求内完成。所涉 store 条目属于内部接口，每一步都做特性探测，探测失败即回退为停用+延后。
 - **待删队列**（回退路径与崩溃兜底）：id 记入 `$DSH_HOME/plugin-data/archived-chats/pending-deletions.json`，会话保持归档与隐藏；下次启动时插件清扫该队列，通过常规删除路径完成物理删除。原地删除也用该队列包裹（删除前登记、文件移除后清除），中途崩溃由下次启动补完。已入队的会话不会出现在列表中；取消归档会撤销待删标记。
 - **标题缓存**：列表刷新时按 id 记忆已解析的标题，不再每次全量读日志；删除与取消归档会使对应缓存失效。
-- **浏览器半**（`lib/client.js`）注册 `settings.section` 插槽项（order 30），用 React 和 DSH 设计令牌渲染页面。
+- **浏览器半**（`lib/client.js`）注册 `settings.section` 插槽项（order 30），用 React 和 rc.7 的 DSH 浮层/状态设计令牌渲染页面。
 
 ## 开发
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -220,8 +220,8 @@ window.__ModuleLoader__.load({
 .dac-page{position:relative;display:flex;flex-direction:column;gap:14px;padding:4px 0 28px;font-family:inherit}
 .dac-head{display:flex;align-items:center;justify-content:space-between;gap:12px}
 .dac-title{margin:0;color:var(--dsw-alias-label-primary);font-size:18px;font-weight:500;line-height:28px;outline:none}
-.dac-deleteall{display:inline-flex;align-items:center;gap:6px;border:none;border-radius:999px;padding:6px 14px;background:rgba(229,72,77,.1);color:#e5484d;font:inherit;font-size:13px;line-height:20px;cursor:pointer;transition:background .15s}
-.dac-deleteall:hover:not(:disabled){background:rgba(229,72,77,.18)}
+.dac-deleteall{display:inline-flex;align-items:center;gap:6px;border:none;border-radius:999px;padding:6px 14px;background:transparent;color:var(--dsw-alias-state-error-primary);font:inherit;font-size:13px;line-height:20px;cursor:pointer;transition:background .15s}
+.dac-deleteall:hover:not(:disabled){background:var(--dsw-alias-interactive-bg-hover-danger)}
 .dac-deleteall:disabled{opacity:.45;cursor:default}
 .dac-search{display:flex;align-items:center;gap:8px;border:1px solid var(--dsw-alias-border-l2);border-radius:10px;background:var(--dsw-alias-bg-layer-1);padding:8px 12px;color:var(--dsw-alias-label-tertiary);transition:border-color .15s}
 .dac-search:focus-within{border-color:var(--dsw-alias-border-l1,var(--dsw-alias-border-l2))}
@@ -240,7 +240,8 @@ window.__ModuleLoader__.load({
 .dac-bulk-actions{display:flex;align-items:center;gap:6px}
 .dac-bulk-btn{border:1px solid var(--dsw-alias-border-l2);border-radius:999px;background:var(--dsw-alias-bg-layer-1);color:var(--dsw-alias-label-primary);font:inherit;font-size:12px;line-height:18px;padding:5px 11px;cursor:pointer}
 .dac-bulk-btn:hover:not(:disabled){background:var(--dsw-alias-interactive-bg-hover,rgba(127,127,127,.12))}
-.dac-bulk-btn.dac-danger{border-color:rgba(229,72,77,.28);color:#e5484d;background:rgba(229,72,77,.08)}
+.dac-bulk-btn.dac-danger{border-color:var(--dsw-alias-state-error-primary);color:var(--dsw-alias-state-error-primary);background:transparent}
+.dac-bulk-btn.dac-danger:hover:not(:disabled){background:var(--dsw-alias-interactive-bg-hover-danger)}
 .dac-bulk-btn:disabled{opacity:.45;cursor:default}
 .dac-group{display:flex;flex-direction:column;gap:8px;margin-top:6px}
 .dac-group-head{position:relative;display:flex;align-items:center;justify-content:space-between;gap:8px;padding:2px}
@@ -255,12 +256,12 @@ window.__ModuleLoader__.load({
 .dac-iconbtn{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border:none;border-radius:8px;background:transparent;color:var(--dsw-alias-label-tertiary);cursor:pointer;transition:background .15s,color .15s;padding:0}
 .dac-iconbtn:hover:not(:disabled){background:var(--dsw-alias-interactive-bg-hover,rgba(127,127,127,.12));color:var(--dsw-alias-label-primary)}
 .dac-iconbtn:disabled{opacity:.45;cursor:default}
-.dac-iconbtn.dac-danger:hover:not(:disabled){color:#e5484d;background:rgba(229,72,77,.1)}
-.dac-menu{position:absolute;right:0;top:30px;z-index:40;min-width:150px;display:flex;flex-direction:column;gap:2px;padding:4px;border:1px solid var(--dsw-alias-border-l2);border-radius:10px;background:var(--dsw-alias-bg-layer-2);box-shadow:0 8px 28px rgba(0,0,0,.18)}
+.dac-iconbtn.dac-danger:hover:not(:disabled){color:var(--dsw-alias-state-error-primary);background:var(--dsw-alias-interactive-bg-hover-danger)}
+.dac-menu{position:absolute;right:0;top:30px;z-index:40;min-width:150px;display:flex;flex-direction:column;gap:2px;padding:4px;border:1px solid var(--dsw-alias-border-inverted);border-radius:10px;background:var(--dsw-specific-menu);box-shadow:var(--dsw-shadow-lv3)}
 .dac-menu-item{border:none;border-radius:7px;background:transparent;color:var(--dsw-alias-label-primary);font:inherit;font-size:13px;line-height:20px;text-align:left;padding:7px 10px;cursor:pointer}
 .dac-menu-item:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(127,127,127,.12))}
-.dac-menu-item.dac-danger{color:#e5484d}
-.dac-menu-item.dac-danger:hover{background:rgba(229,72,77,.1)}
+.dac-menu-item.dac-danger{color:var(--dsw-alias-state-error-primary)}
+.dac-menu-item.dac-danger:hover{background:var(--dsw-alias-interactive-bg-hover-danger)}
 .dac-list{display:flex;flex-direction:column;gap:8px}
 .dac-row{display:flex;align-items:center;justify-content:space-between;gap:12px;border:1px solid var(--dsw-alias-border-l2);border-radius:12px;background:var(--dsw-alias-bg-layer-1);padding:12px 16px;transition:border-color .15s,background .15s}
 .dac-row:hover{border-color:var(--dsw-alias-border-l1,var(--dsw-alias-border-l2))}
@@ -276,24 +277,24 @@ window.__ModuleLoader__.load({
 .dac-empty{display:flex;flex-direction:column;align-items:center;gap:10px;padding:56px 0;color:var(--dsw-alias-label-tertiary);font-size:13px;line-height:20px}
 .dac-center{display:flex;align-items:center;justify-content:center;gap:8px;padding:48px 0;color:var(--dsw-alias-label-tertiary);font-size:13px;line-height:20px}
 .dac-retry{border:1px solid var(--dsw-alias-border-l2);border-radius:8px;background:transparent;color:var(--dsw-alias-label-primary);font:inherit;font-size:12px;padding:4px 12px;cursor:pointer}
-.dac-notice{display:flex;align-items:center;justify-content:space-between;gap:10px;border:1px solid rgba(229,72,77,.45);border-radius:10px;background:rgba(229,72,77,.08);color:#e5484d;font-size:12px;line-height:18px;padding:8px 12px}
+.dac-notice{display:flex;align-items:center;justify-content:space-between;gap:10px;border:1px solid var(--dsw-alias-state-error-primary);border-radius:10px;background:var(--dsw-alias-interactive-bg-hover-danger);color:var(--dsw-alias-state-error-primary);font-size:12px;line-height:18px;padding:8px 12px}
 .dac-notice button{border:none;background:transparent;color:inherit;cursor:pointer;font:inherit;padding:0;display:inline-flex}
-.dac-toast{position:fixed;top:20px;left:50%;transform:translateX(-50%);z-index:1200;display:flex;align-items:center;gap:8px;border:1px solid rgba(48,164,108,.4);border-radius:999px;background:color-mix(in srgb,#30a46c 9%,var(--dsw-alias-bg-primary,#fff));color:#2f9e68;font-size:13px;font-weight:500;line-height:20px;padding:7px 12px 7px 14px;box-shadow:0 6px 20px rgba(0,0,0,.10),0 1px 3px rgba(0,0,0,.06);animation:dac-toast-in .28s cubic-bezier(.21,1.02,.55,1) both}
+.dac-toast{position:fixed;top:20px;left:50%;transform:translateX(-50%);z-index:1200;display:flex;align-items:center;gap:8px;border:1px solid var(--dsw-alias-state-success-secondary);border-radius:999px;background:var(--dsw-alias-state-success-tertiary);color:var(--dsw-alias-state-success-primary);font-size:13px;font-weight:500;line-height:20px;padding:7px 12px 7px 14px;box-shadow:var(--dsw-shadow-lv3);animation:dac-toast-in .28s cubic-bezier(.21,1.02,.55,1) both}
 .dac-toast svg{flex:none}
 .dac-toast button{border:none;background:transparent;color:inherit;opacity:.55;cursor:pointer;font:inherit;padding:2px;margin-left:2px;display:inline-flex;border-radius:999px}
-.dac-toast button:hover{opacity:1;background:rgba(48,164,108,.12)}
+.dac-toast button:hover{opacity:1;background:var(--dsw-alias-state-success-secondary)}
 @keyframes dac-toast-in{from{opacity:0;transform:translateX(-50%) translateY(-10px) scale(.96)}to{opacity:1;transform:translateX(-50%) translateY(0) scale(1)}}
 @media (prefers-reduced-motion:reduce){.dac-toast{animation:none}}
 .dac-confirm-overlay{position:fixed;inset:0;z-index:1400;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.4)}
-.dac-confirm{width:min(400px,calc(100vw - 64px));display:flex;flex-direction:column;gap:12px;border-radius:16px;background:var(--dsw-alias-bg-layer-2);box-shadow:0 16px 64px rgba(0,0,0,.3);padding:20px;outline:none}
-.dac-confirm:focus-visible{box-shadow:0 0 0 2px var(--dsw-alias-interactive-primary,#6e6ef7),0 16px 64px rgba(0,0,0,.3)}
+.dac-confirm{width:min(400px,calc(100vw - 64px));display:flex;flex-direction:column;gap:12px;border:1px solid var(--dsw-alias-border-inverted);border-radius:16px;background:var(--dsw-specific-menu);box-shadow:var(--dsw-shadow-lv3);padding:20px;outline:none}
+.dac-confirm:focus-visible{box-shadow:0 0 0 2px var(--dsw-alias-interactive-primary,#6e6ef7),var(--dsw-shadow-lv3)}
 .dac-confirm-title{color:var(--dsw-alias-label-primary);font-size:15px;font-weight:500;line-height:24px}
 .dac-confirm-body{color:var(--dsw-alias-label-secondary);font-size:13px;line-height:21px}
 .dac-confirm-actions{display:flex;justify-content:flex-end;gap:8px;margin-top:4px}
 .dac-btn{border:1px solid var(--dsw-alias-border-l2);border-radius:9px;background:transparent;color:var(--dsw-alias-label-primary);font:inherit;font-size:13px;line-height:20px;padding:5px 14px;cursor:pointer}
 .dac-btn:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(127,127,127,.12))}
-.dac-btn-danger{border:none;border-radius:9px;background:#e5484d;color:#fff;font:inherit;font-size:13px;line-height:20px;padding:6px 14px;cursor:pointer}
-.dac-btn-danger:hover:not(:disabled){background:#d13438}
+.dac-btn-danger{border:1px solid var(--dsw-alias-state-error-primary);border-radius:9px;background:transparent;color:var(--dsw-alias-state-error-primary);font:inherit;font-size:13px;line-height:20px;padding:5px 14px;cursor:pointer}
+.dac-btn-danger:hover:not(:disabled){background:var(--dsw-alias-interactive-bg-hover-danger)}
 .dac-btn-danger:disabled{opacity:.5;cursor:default}
 .dac-spin{display:inline-block;width:14px;height:14px;border:2px solid var(--dsw-alias-label-tertiary);border-top-color:transparent;border-radius:50%;animation:dac-rotate .8s linear infinite}
 @keyframes dac-rotate{to{transform:rotate(360deg)}}
@@ -321,24 +322,35 @@ window.__ModuleLoader__.load({
 		const NAV_LABELS = ["已归档的聊天", "Archived Chats"];
 		const ARCHIVE_ICON_INNER = '<rect x="3" y="4" width="18" height="5" rx="1"></rect><path d="M5 9v9a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V9"></path><path d="M10 13h4"></path>';
 
+		function safeQueryAll(root, selector) {
+			try {
+				return typeof root?.querySelectorAll === "function" ? root.querySelectorAll(selector) : [];
+			} catch {
+				return [];
+			}
+		}
+
 		function patchNavIcons() {
 			if (typeof document === "undefined" || document.body === null) return;
-			const dialogs = document.querySelectorAll('[role="dialog"]');
+			const dialogs = safeQueryAll(document, '[role="dialog"]');
 			for (const dialog of dialogs) {
-				const buttons = dialog.querySelectorAll("nav button");
+				const buttons = safeQueryAll(dialog, "nav button");
 				for (const button of buttons) {
-					const text = button.textContent ?? "";
+					const text = typeof button?.textContent === "string" ? button.textContent : "";
 					if (!NAV_LABELS.some((label) => text.includes(label))) continue;
-					const svg = button.querySelector("svg");
-					if (svg === null || svg.dataset.dacPatched === "1") continue;
-					svg.dataset.dacPatched = "1";
-					svg.setAttribute("viewBox", "0 0 24 24");
-					svg.setAttribute("fill", "none");
-					svg.setAttribute("stroke", "currentColor");
-					svg.setAttribute("stroke-width", "1.5");
-					svg.setAttribute("stroke-linecap", "round");
-					svg.setAttribute("stroke-linejoin", "round");
-					svg.innerHTML = ARCHIVE_ICON_INNER;
+					let svg = null;
+					try { svg = typeof button.querySelector === "function" ? button.querySelector("svg") : null; } catch { continue; }
+					if (svg === null || svg.dataset === void 0 || svg.dataset.dacPatched === "1" || typeof svg.setAttribute !== "function") continue;
+					try {
+						svg.dataset.dacPatched = "1";
+						svg.setAttribute("viewBox", "0 0 24 24");
+						svg.setAttribute("fill", "none");
+						svg.setAttribute("stroke", "currentColor");
+						svg.setAttribute("stroke-width", "1.5");
+						svg.setAttribute("stroke-linecap", "round");
+						svg.setAttribute("stroke-linejoin", "round");
+						svg.innerHTML = ARCHIVE_ICON_INNER;
+					} catch { /* keep the host-provided fallback icon */ }
 				}
 			}
 		}
@@ -347,15 +359,22 @@ window.__ModuleLoader__.load({
 
 		function startNavIconPatch() {
 			patchNavIcons();
-			const Observer = typeof window !== "undefined" ? window.MutationObserver : void 0;
+			let Observer;
+			try { Observer = typeof window !== "undefined" ? window.MutationObserver : void 0; } catch { return; }
 			if (Observer === void 0 || typeof document === "undefined" || document.body === null) return;
 			if (navObserver !== null) return;
-			navObserver = new Observer(() => patchNavIcons());
-			navObserver.observe(document.body, { childList: true, subtree: true });
+			let observer = null;
+			try {
+				observer = new Observer(() => patchNavIcons());
+				observer.observe(document.body, { childList: true, subtree: true });
+				navObserver = observer;
+			} catch {
+				try { observer?.disconnect?.(); } catch { /* best-effort decoration cleanup */ }
+			}
 		}
 
 		function stopNavIconPatch() {
-			navObserver?.disconnect();
+			try { navObserver?.disconnect?.(); } catch { /* best-effort decoration cleanup */ }
 			navObserver = null;
 		}
 		//#endregion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-archived-chats",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "DeepSeek Harness 已归档会话管理页：搜索、排序、批量选择、取消归档和删除。An Archived Chats settings page for DeepSeek Harness with search, sorting, bulk selection, unarchive, and delete.",
   "license": "MIT",
   "author": "Ultronen",

--- a/test/smoke.test.mjs
+++ b/test/smoke.test.mjs
@@ -460,6 +460,24 @@ console.log('\n[11] client half — settings section registration');
   assert(style !== undefined, 'page stylesheet injected into <head>');
   assert(style?.attrs['data-plugin-css'] === 'dsh-archived-chats', 'stylesheet carries the data-plugin-css marker');
   assert(style?.textContent.includes('.dac-row'), 'stylesheet paints the chat rows');
+  assert(
+    style?.textContent.includes('background:var(--dsw-specific-menu)')
+      && style?.textContent.includes('border:1px solid var(--dsw-alias-border-inverted)')
+      && style?.textContent.includes('box-shadow:var(--dsw-shadow-lv3)'),
+    'menus and dialogs use the rc.7 overlay surface tokens',
+  );
+  assert(
+    style?.textContent.includes('var(--dsw-alias-state-error-primary)')
+      && style?.textContent.includes('var(--dsw-alias-interactive-bg-hover-danger)')
+      && style?.textContent.includes('var(--dsw-alias-state-success-primary)')
+      && style?.textContent.includes('var(--dsw-alias-state-success-tertiary)'),
+    'destructive and success states use rc.7 semantic tokens',
+  );
+  assert(
+    !/(?:#e5484d|#d13438|#30a46c|#2f9e68|rgba\(229,72,77|rgba\(48,164,108)/i.test(style?.textContent ?? ''),
+    'legacy hard-coded destructive and success colors are absent',
+  );
+  assert(!clientSource.includes('settings.plugin.item'), 'rc.7 keyed plugin-item slot is not used by the settings section');
 }
 
 function collectElements(node, result = []) {
@@ -615,6 +633,37 @@ console.log('\n[13] client half — settings nav icon patch');
   observers[0].cb();
   assert(gearSvg.innerHTML.includes('<rect'), 're-patching is idempotent');
   mockDialogs = [];
+}
+
+console.log('\n[13b] client half — nav icon patch degrades safely on an unknown host DOM');
+{
+  let defensiveModule = null;
+  const hostileWindow = {
+    ...windowMock,
+    __ModuleLoader__: { load: (def) => { defensiveModule = def; } },
+    MutationObserver: class {
+      observe() { throw new Error('observer rejected host root'); }
+      disconnect() {}
+    },
+  };
+  const hostileDocument = {
+    ...documentMock,
+    body: {},
+    querySelectorAll: () => { throw new Error('host settings DOM changed'); },
+  };
+  const fn = new Function('window', 'document', 'require', clientSource);
+  fn(hostileWindow, hostileDocument, (name) => moduleTable[name]);
+  const defensiveExports = defensiveModule?.factory((name) => moduleTable[name]);
+  let threw = false;
+  try {
+    defensiveExports.apply({
+      ...clientCtx,
+      slots: { inject: (_name, register) => register(), register: () => () => {} },
+    });
+  } catch {
+    threw = true;
+  }
+  assert(!threw, 'host DOM or observer changes cannot prevent the plugin section from loading');
 }
 
 // Tear down the isolated DSH_HOME and session fixture dirs.


### PR DESCRIPTION
## What changed

- align menus, dialogs, destructive actions, and success feedback with Harness rc.7 design tokens
- make the settings navigation icon patch fail safely when host DOM contracts change
- document the rc.7 compatibility baseline and bump the package to 0.5.1
- add regression coverage for rc.7 slot/style contracts and hostile host DOM behavior

## Why

Harness rc.7 updated plugin-market UI contracts and overlay styling. The archived chats section still uses the stable top-level `settings.section` slot, but its visual tokens and decorative DOM patch needed hardening.

## Validation

- `npm test`
- `node --check lib/client.js`
- `node --check lib/index.js`
- `node --check test/smoke.test.mjs`
- `npm pack --dry-run --json`
- local rc.7 archive API returned HTTP 200