### PR TITLE
docs: sharpen archived chats discovery

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,5 +1,10 @@
 # dsh-archived-chats
 
+[![npm version](https://img.shields.io/npm/v/dsh-archived-chats)](https://www.npmjs.com/package/dsh-archived-chats)
+[![npm downloads](https://img.shields.io/npm/dm/dsh-archived-chats)](https://www.npmjs.com/package/dsh-archived-chats)
+[![CI](https://github.com/Ultronen/dsh-archived-chats/actions/workflows/ci.yml/badge.svg)](https://github.com/Ultronen/dsh-archived-chats/actions/workflows/ci.yml)
+[![Awesome DSH Plugin](https://awesome-dsh-plugin.com/badge.svg)](https://awesome-dsh-plugin.com/p/Ultronen/dsh-archived-chats/)
+
 [English](README.en.md) | [中文](README.md)
 
 > 🔎 **Archived no longer means lost.** Search conversation content, read complete messages and tool calls, then back up, restore, or delete safely.
@@ -9,6 +14,17 @@
 A local conversation archive center for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness): recover, search, read, back up, restore, or delete archived sessions.
 
 Once a conversation is archived in DeepSeek Harness it disappears from the sidebar, and there is no built-in way to browse it again — only the workspace store (`~/.dsh/storages/workspace.json`) still remembers it. This plugin adds an **Archived Chats** page under Settings where every archived session is visible, searchable, and manageable.
+
+[Plugin market](https://awesome-dsh-plugin.com/p/Ultronen/dsh-archived-chats/) · [npm](https://www.npmjs.com/package/dsh-archived-chats) · [Releases](https://github.com/Ultronen/dsh-archived-chats/releases) · [Questions and feedback](https://github.com/Ultronen/dsh-archived-chats/discussions) · [Private vulnerability reporting](https://github.com/Ultronen/dsh-archived-chats/security/advisories/new)
+
+<p align="center">
+  <a href="assets/screenshots/8-conversation-preview.png"><img src="assets/screenshots/8-conversation-preview.png" width="49%" alt="Full-text search and read-only preview for archived chats"></a>
+  <a href="assets/screenshots/9-recycle-bin.png"><img src="assets/screenshots/9-recycle-bin.png" width="49%" alt="Archived-chat Recycle Bin with automatic protection snapshots"></a>
+</p>
+
+<p align="center"><sub>Search and read without unarchiving first; ordinary deletion moves through a protection-snapshot Recycle Bin.</sub></p>
+
+If this plugin helps you recover or protect an important conversation, consider starring the repository so people who need archived-chat recovery can discover it more easily.
 
 ## 🚀 Install
 
@@ -34,8 +50,6 @@ Screenshots 1–7 were captured from 0.9.0 in a local DeepSeek Harness `0.1.0-rc
 
 ![Archived Chats overview](assets/screenshots/1-archived-chats.png)
 ![Search and filters](assets/screenshots/2-search.png)
-![Read-only archived conversation preview](assets/screenshots/8-conversation-preview.png)
-![Recycle Bin with automatic protection snapshot](assets/screenshots/9-recycle-bin.png)
 ![Group actions](assets/screenshots/4-group-menu.png)
 ![Metadata editor](assets/screenshots/5-metadata-editor.png)
 ![Bulk actions](assets/screenshots/6-bulk-actions.png)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # dsh-archived-chats
 
+[![npm version](https://img.shields.io/npm/v/dsh-archived-chats)](https://www.npmjs.com/package/dsh-archived-chats)
+[![npm downloads](https://img.shields.io/npm/dm/dsh-archived-chats)](https://www.npmjs.com/package/dsh-archived-chats)
+[![CI](https://github.com/Ultronen/dsh-archived-chats/actions/workflows/ci.yml/badge.svg)](https://github.com/Ultronen/dsh-archived-chats/actions/workflows/ci.yml)
+[![Awesome DSH Plugin](https://awesome-dsh-plugin.com/badge.svg)](https://awesome-dsh-plugin.com/p/Ultronen/dsh-archived-chats/)
+
 [English](README.en.md) | 中文
 
 > 🔎 **归档不再等于消失。** 直接搜索聊天正文、阅读完整对话和工具调用，然后安全备份、恢复或删除。
@@ -9,6 +14,17 @@
 为 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 新增一个本地会话归档中心：找回、搜索、阅读、备份、恢复或删除被归档的会话。
 
 在 DeepSeek Harness 里，聊天一旦归档就会从侧边栏消失，界面中没有任何入口可以再看到它，只有工作区存档（`~/.dsh/storages/workspace.json`）还记得它。这个插件在「设置」中补上一个「已归档的聊天」页面，让所有归档会话都可见、可搜索、可管理。
+
+[插件市场](https://awesome-dsh-plugin.com/p/Ultronen/dsh-archived-chats/) · [npm](https://www.npmjs.com/package/dsh-archived-chats) · [版本发布](https://github.com/Ultronen/dsh-archived-chats/releases) · [问题交流](https://github.com/Ultronen/dsh-archived-chats/discussions) · [私密报告漏洞](https://github.com/Ultronen/dsh-archived-chats/security/advisories/new)
+
+<p align="center">
+  <a href="assets/screenshots/8-conversation-preview.png"><img src="assets/screenshots/8-conversation-preview.png" width="49%" alt="归档聊天正文搜索与只读对话预览"></a>
+  <a href="assets/screenshots/9-recycle-bin.png"><img src="assets/screenshots/9-recycle-bin.png" width="49%" alt="带自动保护快照的归档聊天回收站"></a>
+</p>
+
+<p align="center"><sub>无需先取消归档即可搜索和阅读；普通删除先进入带保护快照的回收站。</sub></p>
+
+如果它帮你找回或保护过一次重要对话，欢迎给仓库一个 Star——这能帮助真正需要归档恢复功能的用户更容易发现它。
 
 ## 🚀 安装
 
@@ -34,8 +50,6 @@ dsh plugin --profile web update dsh-archived-chats
 
 ![已归档的聊天总览](assets/screenshots/1-archived-chats.png)
 ![搜索与筛选](assets/screenshots/2-search.png)
-![归档对话只读预览](assets/screenshots/8-conversation-preview.png)
-![回收站与自动保护快照](assets/screenshots/9-recycle-bin.png)
 ![分组操作](assets/screenshots/4-group-menu.png)
 ![标签与备注编辑](assets/screenshots/5-metadata-editor.png)
 ![批量操作](assets/screenshots/6-bulk-actions.png)


### PR DESCRIPTION
## Summary

- add npm, CI, and Awesome DSH discovery badges
- link directly to the plugin market, npm, releases, Discussions, and private vulnerability reporting
- move the archived-conversation preview and protected Recycle Bin into a compact first-screen visual
- add a restrained Star prompt after the product value is demonstrated

## Verification

- `npm test` — 99 tests passed
- `git diff --check`
- verified the market page and badge endpoints return HTTP 200
- `npm pack --dry-run --json` — runtime package remains 29 files

This is a bilingual documentation-only change. It does not change runtime code, package version, npm publication, or the plugin-market repository.