### PR TITLE
test: wait for recycle migration completion

### DIFF
--- a/test/smoke.test.mjs
+++ b/test/smoke.test.mjs
@@ -924,7 +924,10 @@ console.log('\n[9] boot migration — deferred deletions become recoverable tras
   };
   const persistence2 = {
     list: async () => [{ id: 'session-live', createdAt: 1 }],
-    inspect: async () => ({ meta: { id: 'session-live', createdAt: 1 }, events: [] }),
+    inspect: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      return { meta: { id: 'session-live', createdAt: 1 }, events: [] };
+    },
     listSnapshots: async () => [{ header: { id: 'session-live', createdAt: 1 }, revision: 'rev-session-live' }],
     locate: (h) => ({ kind: 'jsonl', path: join(tmp, String(h.id), 'session.jsonl.zstd') }),
   };
@@ -944,7 +947,7 @@ console.log('\n[9] boot migration — deferred deletions become recoverable tras
   assert(readPendingStore().includes('session-live'), 'pending store holds the parked id before boot');
   services2.webServer = { register: (r) => { routes2.set(r.path, r.handler); return () => routes2.delete(r.path); } };
   listeners2.find(([event]) => event === 'internal/service')?.[1]('webServer');
-  await new Promise((resolve) => setTimeout(resolve, 200));
+  await waitUntil(() => readPendingStore().length === 0, 3000);
   assert(existsSync(join(tmp, 'session-live')), 'migration preserves the session directory');
   assert(state2.archivedSessionIds.includes('session-live'), 'migration keeps archive membership');
   assert(readPendingStore().length === 0, 'pending store drains after trash commit');


### PR DESCRIPTION
## Summary

- replace the boot-migration smoke test fixed 200ms sleep with a bounded wait for the pending-deletion store to drain
- add a deterministic 300ms persistence delay so the regression reproduces the Node 18 timing race on every runtime
- keep the production recycle migration unchanged

## TDD evidence

- RED: with the 300ms fixture delay and the old 200ms sleep, the same two assertions failed: pending store did not drain and the migrated row was absent
- GREEN: using the existing `waitUntil` helper with a 3-second failure bound makes both assertions pass after the real completion condition

## Verification

- `node test/smoke.test.mjs`
- `npm test` — 99 tests passed
- `npm pack --dry-run --json` — 29 runtime package files
- `git diff --check`

This fixes CI test timing only; it does not change plugin runtime code, package version, npm publication, or marketplace data.