### PR TITLE
feat: rename settings entry to Session Archive

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -13,7 +13,7 @@
 
 A local archived-chat manager for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness): search and preview complete conversations, back up and restore sessions, and safely manage history with an undoable Recycle Bin, recovery snapshots, retention policies, and Origins & Branches.
 
-Once a conversation is archived in DeepSeek Harness it disappears from the sidebar, and there is no built-in way to browse it again — only the workspace store (`~/.dsh/storages/workspace.json`) still remembers it. This plugin adds an **Archived Chats** page under Settings where every archived session is visible, searchable, and manageable.
+Once a conversation is archived in DeepSeek Harness it disappears from the sidebar, and there is no built-in way to browse it again — only the workspace store (`~/.dsh/storages/workspace.json`) still remembers it. This plugin adds a **Session Archive** page under Settings where every archived session is visible, searchable, and manageable.
 
 [Plugin market](https://awesome-dsh-plugin.com/p/Ultronen/dsh-archived-chats/) · [npm](https://www.npmjs.com/package/dsh-archived-chats) · [Releases](https://github.com/Ultronen/dsh-archived-chats/releases) · [Questions and feedback](https://github.com/Ultronen/dsh-archived-chats/discussions) · [Private vulnerability reporting](https://github.com/Ultronen/dsh-archived-chats/security/advisories/new)
 
@@ -32,7 +32,7 @@ If this plugin helps you recover or protect an important conversation, consider 
 dsh plugin --profile web add dsh-archived-chats@latest
 ```
 
-Restart DSH once after installing, then open **Settings → Archived Chats**.
+Restart DSH once after installing, then open **Settings → Session Archive**.
 
 To update an existing installation:
 
@@ -50,7 +50,7 @@ These screenshots cover the current `0.12.0` feature set. They were captured in 
 
 ![Archive a conversation from its session menu](assets/screenshots/01-archive-entry.png)
 ![Three-second archive success notice](assets/screenshots/01b-archive-success.png)
-![Archived Chats overview](assets/screenshots/02-archived-overview.png)
+![Session Archive overview](assets/screenshots/02-archived-overview.png)
 ![Full-text conversation and tool-result search](assets/screenshots/03-full-text-search.png)
 ![Read-only archived conversation preview](assets/screenshots/04-conversation-preview.png)
 ![Tags and notes editor](assets/screenshots/05-metadata-editor.png)
@@ -67,7 +67,7 @@ These screenshots cover the current `0.12.0` feature set. They were captured in 
 ## Usage
 
 1. Archive a conversation from the normal DSH session menu. After the Host confirms success, a **Chat archived** notice appears at the top for three seconds with direct **View** and **Undo** actions; hovering or focusing it pauses the timer. Archiving removes the chat from the sidebar but keeps its session data in the workspace store.
-2. Open **Settings → Archived Chats**. The page groups archived conversations by workspace and remembers collapsed groups in this browser.
+2. Open **Settings → Session Archive**. The page groups archived conversations by workspace and remembers collapsed groups in this browser.
 3. Search titles, tags, notes, conversation text, or tool output. Open the row preview to read an archived conversation without unarchiving it. Click **Select multiple** only when you need bulk actions.
 4. Click **Import backup** to choose a ZIP produced by this plugin and confirm non-conflicting sessions after the preview. Click **Export backup** to export the current selection, or every archived chat when nothing is selected. Individual rows also have an export action.
 5. Choose **Unarchive** to return a conversation to the sidebar. **Move to Recycle Bin** creates a protection snapshot and offers immediate **Undo**; the session can also be restored later from the **Recycle Bin** tab. Only **Delete permanently / Empty Recycle Bin** removes originals and snapshots irreversibly.
@@ -249,7 +249,7 @@ The suite (`test/*.test.mjs`) covers export records and real ZIP decoding, bound
 
 ### 0.3.0
 
-- First published release of the Archived Chats settings page.
+- First published release of the Session Archive settings page.
 - Added workspace-grouped browsing, title search, type/project filters, unarchive, and confirmed single/group/all deletion.
 - Added host routes, the browser settings section, and the pending-deletion sweep for live sessions.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 为 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 新增一个本地归档聊天中心：搜索和预览完整对话，备份与恢复会话，并通过可撤销回收站、恢复快照、保留策略及来源与分支安全管理历史聊天。
 
-在 DeepSeek Harness 里，聊天一旦归档就会从侧边栏消失，界面中没有任何入口可以再看到它，只有工作区存档（`~/.dsh/storages/workspace.json`）还记得它。这个插件在「设置」中补上一个「已归档的聊天」页面，让所有归档会话都可见、可搜索、可管理。
+在 DeepSeek Harness 里，聊天一旦归档就会从侧边栏消失，界面中没有任何入口可以再看到它，只有工作区存档（`~/.dsh/storages/workspace.json`）还记得它。这个插件在「设置」中补上一个「会话档案」页面，让所有归档会话都可见、可搜索、可管理。
 
 [插件市场](https://awesome-dsh-plugin.com/p/Ultronen/dsh-archived-chats/) · [npm](https://www.npmjs.com/package/dsh-archived-chats) · [版本发布](https://github.com/Ultronen/dsh-archived-chats/releases) · [问题交流](https://github.com/Ultronen/dsh-archived-chats/discussions) · [私密报告漏洞](https://github.com/Ultronen/dsh-archived-chats/security/advisories/new)
 
@@ -32,7 +32,7 @@
 dsh plugin --profile web add dsh-archived-chats@latest
 ```
 
-安装后重启一次 DSH，然后打开 **设置 → 已归档的聊天**。
+安装后重启一次 DSH，然后打开 **设置 → 会话档案**。
 
 更新已有安装：
 
@@ -50,7 +50,7 @@ dsh plugin --profile web update dsh-archived-chats
 
 ![从会话菜单点击归档](assets/screenshots/01-archive-entry.png)
 ![归档成功后的三秒提示](assets/screenshots/01b-archive-success.png)
-![已归档的聊天总览](assets/screenshots/02-archived-overview.png)
+![会话档案总览](assets/screenshots/02-archived-overview.png)
 ![聊天正文与工具结果全文搜索](assets/screenshots/03-full-text-search.png)
 ![归档对话只读预览](assets/screenshots/04-conversation-preview.png)
 ![标签与备注编辑](assets/screenshots/05-metadata-editor.png)
@@ -66,8 +66,8 @@ dsh plugin --profile web update dsh-archived-chats
 
 ## 使用流程
 
-1. 在 DSH 正常聊天的会话菜单中点击归档。宿主确认成功后，页面顶部会显示 3 秒的 **已归档的聊天** 提示，可立即 **查看** 归档中心或 **撤销**；悬停或键盘聚焦时计时暂停。归档只会把会话从侧边栏隐藏，工作区存档仍会保留会话数据。
-2. 打开 **设置 → 已归档的聊天**。页面按工作区分组，并在当前浏览器中记住分组的折叠状态。
+1. 在 DSH 正常聊天的会话菜单中点击归档。宿主确认成功后，页面顶部会显示 3 秒的 **已归档的聊天** 提示，可立即 **查看** 会话档案或 **撤销**；悬停或键盘聚焦时计时暂停。归档只会把会话从侧边栏隐藏，工作区存档仍会保留会话数据。
+2. 打开 **设置 → 会话档案**。页面按工作区分组，并在当前浏览器中记住分组的折叠状态。
 3. 搜索标题、标签、备注、聊天正文或工具结果；点击行内预览按钮可直接阅读归档对话，无需先取消归档。需要多选时点击 **批量选择** 显示复选框。
 4. 点击顶部 **导入备份** 选择本插件导出的 ZIP，预览后确认无冲突会话；点击 **导出备份** 导出当前选中项，未选择时导出全部归档会话。单条会话也可以从行内操作导出。
 5. 点击 **取消归档** 将会话放回侧边栏；点击 **移至回收站** 会创建保护快照，可立即点击 **撤销**，也可稍后在 **回收站** 标签恢复。只有回收站中的 **永久删除 / 清空回收站** 会不可撤销地移除原会话和快照。
@@ -249,7 +249,7 @@ npm test
 
 ### 0.3.0
 
-- 首个公开发布版本，提供「已归档的聊天」设置页。
+- 首个公开发布版本，提供「会话档案」设置页。
 - 新增按工作区分组浏览、标题搜索、类型/项目筛选、取消归档，以及带确认的单条/分组/全部删除。
 - 新增 Host 路由、浏览器设置区块，以及用于处理运行中会话的待删队列清扫。
 

--- a/docs/ARCHITECTURE.en.md
+++ b/docs/ARCHITECTURE.en.md
@@ -9,7 +9,7 @@ This document is for maintainers and developers who need to understand data beha
 The plugin has a Host service half and a browser client half:
 
 - The Host service in lib/index.js runs inside the DSH Web host, reads the workspace registry and session persistence, and exposes local HTTP routes.
-- The browser client in lib/client.js registers the Archived Chats settings.section and renders state and actions.
+- The browser client in lib/client.js registers the Session Archive settings.section and renders state and actions.
 - Pure domain logic lives in lib/export.js, lib/import.js, lib/restore.js, lib/metadata.js, lib/search.js, lib/stats.js, lib/insights.js, lib/retention.js, lib/retention-service.js, and lib/lineage.js. lib/trash.js owns the recycle catalog, lib/snapshot.js owns verified snapshots, and lib/recycle.js composes recycle lifecycle operations.
 
 The browser never reads session files directly. All reads and writes go through Host routes.
@@ -113,7 +113,7 @@ Permanent purge persists `purge-pending` before physical writes, then removes th
 
 client.js registers an order-30 settings.section and uses the DSH rc.7 overlay, state, and design tokens. The page state includes:
 
-- A frame-wide archive success notice in `shell.overlay`: during its effect lifetime the plugin wraps the public `workspaces.archiveSession` method, publishes the latest session ID only after the original call succeeds, and restores the method on unload. The notice defaults to three seconds and tracks pointer/focus pause reasons independently. View follows the Host's accessible Settings trigger and Archived Chats nav label; Undo calls the guarded `/unarchive` route and refreshes the workspace projection. Failures remain retryable and never present false success.
+- A frame-wide archive success notice in `shell.overlay`: during its effect lifetime the plugin wraps the public `workspaces.archiveSession` method, publishes the latest session ID only after the original call succeeds, and restores the method on unload. The notice defaults to three seconds and tracks pointer/focus pause reasons independently. View follows the Host's accessible Settings trigger and Session Archive nav label; Undo calls the guarded `/unarchive` route and refreshes the workspace projection. Failures remain retryable and never present false success.
 - Archived sessions and workspace groups.
 - Search, type/project/tag filters, and sorting.
 - Tag and note editor.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,7 @@
 插件由 Host 服务层和浏览器客户端两部分组成：
 
 - Host 服务层位于 lib/index.js，运行在 DSH Web 宿主中，读取工作区注册表和会话持久层，并提供本地 HTTP 路由。
-- 浏览器客户端位于 lib/client.js，通过 settings.section 注册「已归档的聊天」设置页，负责展示状态和发起操作。
+- 浏览器客户端位于 lib/client.js，通过 settings.section 注册「会话档案」设置页，负责展示状态和发起操作。
 - 纯领域逻辑拆分在 lib/export.js、lib/import.js、lib/restore.js、lib/metadata.js、lib/search.js、lib/stats.js、lib/insights.js、lib/retention.js、lib/retention-service.js 和 lib/lineage.js 中。lib/trash.js 负责版本化回收目录，lib/snapshot.js 负责可验证保护快照，lib/recycle.js 组合回收生命周期。
 
 浏览器不直接访问会话文件。所有读取和写入都经 Host 路由完成。

--- a/docs/superpowers/plans/2026-08-25-v0.12-release-screenshots.md
+++ b/docs/superpowers/plans/2026-08-25-v0.12-release-screenshots.md
@@ -15,7 +15,7 @@
 - Capture only the real plugin UI; generated, mocked, composited, or edited stand-ins are forbidden.
 - Use an isolated temporary `DSH_HOME` with synthetic sessions and no credentials, API keys, real conversations, or real workspace paths.
 - Capture Chinese, light theme, at `1470x712` unless the archive-entry surface requires its natural `1470x587` crop.
-- Keep the product name and settings navigation label `已归档的聊天` / `Archived Chats`.
+- Keep the product name and settings navigation label `会话档案` / `Session Archive`.
 - Use `恢复快照` / `recovery snapshot` for the user outcome; reserve `保护快照` / `protection snapshot` for low-level integrity and permanent-purge explanations.
 - Every settings-page screenshot must show the four v0.12 views: `归档`, `回收站`, `空间与策略`, `来源与分支`.
 - Full session IDs may appear only in the dedicated compact-ID/copy treatment or where a technical confirmation genuinely requires one.

--- a/lib/client.js
+++ b/lib/client.js
@@ -177,7 +177,7 @@ window.__ModuleLoader__.load({
 		//#region locale
 		const zh = {
 			"locale.intl": "zh-CN",
-			"nav": "已归档的聊天",
+			"nav": "会话档案",
 			"archiveNotice.title": "已归档的聊天",
 			"archiveNotice.view": "查看",
 			"archiveNotice.opening": "正在打开…",
@@ -187,8 +187,8 @@ window.__ModuleLoader__.load({
 			"archiveNotice.close": "关闭归档提示",
 			"archiveNotice.settings": "设置",
 			"archiveNotice.undoError": "撤销失败，请重试",
-			"archiveNotice.viewError": "无法打开归档页面，请重试",
-				"page.title": "已归档的聊天",
+			"archiveNotice.viewError": "无法打开会话档案，请重试",
+				"page.title": "会话档案",
 				"tab.archived": "归档",
 				"tab.trash": "回收站",
 				"tab.insights": "空间与策略",
@@ -400,7 +400,7 @@ window.__ModuleLoader__.load({
 		};
 		const en = {
 			"locale.intl": "en-US",
-			"nav": "Archived Chats",
+			"nav": "Session Archive",
 			"archiveNotice.title": "Chat archived",
 			"archiveNotice.view": "View",
 			"archiveNotice.opening": "Opening…",
@@ -410,8 +410,8 @@ window.__ModuleLoader__.load({
 			"archiveNotice.close": "Close archive notice",
 			"archiveNotice.settings": "Settings",
 			"archiveNotice.undoError": "Undo failed. Try again",
-			"archiveNotice.viewError": "Could not open Archived Chats. Try again",
-				"page.title": "Archived Chats",
+			"archiveNotice.viewError": "Could not open Session Archive. Try again",
+				"page.title": "Session Archive",
 				"tab.archived": "Archived",
 				"tab.trash": "Recycle Bin",
 				"tab.insights": "Storage & Retention",
@@ -1201,7 +1201,7 @@ window.__ModuleLoader__.load({
 		// button's icon in place — mutating the existing <svg> (never replacing
 		// React-managed nodes) and re-marking through dataset, so locale
 		// re-renders and dialog reopens simply get re-patched by the observer.
-		const NAV_LABELS = ["已归档的聊天", "Archived Chats"];
+		const NAV_LABELS = ["会话档案", "Session Archive"];
 		const ARCHIVE_ICON_INNER = '<rect x="3" y="4" width="18" height="5" rx="1"></rect><path d="M5 9v9a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V9"></path><path d="M10 13h4"></path>';
 
 		function safeQueryAll(root, selector) {

--- a/lib/types/client/index.d.ts
+++ b/lib/types/client/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Browser client entry — the Archived Chats settings section. It keeps the
+ * Browser client entry — the Session Archive settings section. It keeps the
  * existing searchable archive manager and adds Archived, Recycle Bin, Storage
  * & Retention, and Origins & Branches views. Removing an archived chat from
  * this plugin moves it to recoverable trash and

--- a/test/smoke.test.mjs
+++ b/test/smoke.test.mjs
@@ -1478,7 +1478,7 @@ console.log('\n[10b] client model — sorting and visible selection');
   let viewPaints = 0;
   const settingsTrigger = { textContent: '设置', click: () => { settingsTriggerClicks += 1; settingsOpen = true; } };
   const unrelatedDialogTrigger = { textContent: '打开预览', click: () => {} };
-  const archiveNav = { textContent: ' 已归档的聊天 ', click: () => { archiveNavClicks += 1; } };
+  const archiveNav = { textContent: ' 会话档案 ', click: () => { archiveNavClicks += 1; } };
   const generalNav = { textContent: '通用', click: () => {} };
   const settingsDocument = {
     querySelectorAll(selector) {
@@ -1488,7 +1488,7 @@ console.log('\n[10b] client model — sorting and visible selection');
     },
   };
   const openedArchiveSettings = await clientExports.__test.openArchiveSettings?.(
-    (key) => ({ nav: '已归档的聊天', 'archiveNotice.settings': '设置' })[key] ?? key,
+    (key) => ({ nav: '会话档案', 'archiveNotice.settings': '设置' })[key] ?? key,
     settingsDocument,
     async () => { viewPaints += 1; },
   );
@@ -1496,7 +1496,7 @@ console.log('\n[10b] client model — sorting and visible selection');
     'archive notice View opens Settings and selects the archived-chat section after it mounts');
   settingsOpen = true;
   const reopenedArchiveSettings = await clientExports.__test.openArchiveSettings?.(
-    (key) => ({ nav: '已归档的聊天', 'archiveNotice.settings': '设置' })[key] ?? key,
+    (key) => ({ nav: '会话档案', 'archiveNotice.settings': '设置' })[key] ?? key,
     settingsDocument,
     async () => { viewPaints += 1; },
   );
@@ -1994,7 +1994,7 @@ console.log('\n[11] client half — settings section registration');
   assert(clientCalls.localeRegister.length === 1, 'locale dictionaries registered once');
   assert(clientCalls.localeRegister[0].ns === 'settings.archived-chats', 'locale namespace is settings.archived-chats');
   const zhDict = clientCalls.localeRegister[0].dicts.zh;
-  assert(zhDict['nav'] === '已归档的聊天', 'zh nav label is 已归档的聊天');
+  assert(zhDict['nav'] === '会话档案' && zhDict['page.title'] === '会话档案', 'zh session archive label and page title are localized');
   assert(zhDict['delete.all'] === '全部移至回收站', 'zh recycle-all label present');
   assert(zhDict['confirm.deleteOne.title'] === '移至回收站？', 'move-one confirmation title is localized');
   assert(zhDict['confirm.deleteOne.body'].includes('保护快照'), 'move-one confirmation explains recoverability');
@@ -2005,6 +2005,9 @@ console.log('\n[11] client half — settings section registration');
     && zhDict['archiveNotice.undo'] === '撤销',
   'Chinese archive success notice actions are localized');
   assert(clientCalls.localeRegister[0].dicts.en['export.row'] === 'Export backup', 'English row export action is localized');
+  assert(clientCalls.localeRegister[0].dicts.en['nav'] === 'Session Archive'
+    && clientCalls.localeRegister[0].dicts.en['page.title'] === 'Session Archive',
+  'English session archive label and page title are localized');
   assert(clientCalls.localeRegister[0].dicts.en['archiveNotice.title'] === 'Chat archived'
     && clientCalls.localeRegister[0].dicts.en['archiveNotice.view'] === 'View'
     && clientCalls.localeRegister[0].dicts.en['archiveNotice.undo'] === 'Undo',
@@ -2017,7 +2020,7 @@ console.log('\n[11] client half — settings section registration');
   assert(meta.id === 'archived-chats', `section id is "archived-chats" (got "${meta.id}")`);
   assert(meta.order === 30, `section order is 30 (got ${meta.order})`);
   assert(typeof meta.label === 'function', 'nav label is a locale-bound function');
-  assert(meta.label() === '已归档的聊天', `label() resolves to 已归档的聊天 (got "${meta.label()}")`);
+  assert(meta.label() === '会话档案', `label() resolves to 会话档案 (got "${meta.label()}")`);
   assert(meta.locale === 'settings.archived-chats', 'section carries its locale namespace');
   assert(typeof settingsRegistration?.component === 'function', 'section component is a function');
   assert(overlayRegistration?.meta?.id === 'archived-chats-success'
@@ -3759,7 +3762,7 @@ console.log('\n[13] client half — settings nav icon patch');
   assert(observers[0].opts?.subtree === true && observers[0].opts?.childList === true, 'observer watches the body subtree');
   const gearSvg = { dataset: {}, attrs: {}, innerHTML: '<circle cx="12" cy="12" r="3"/>', setAttribute(k, v) { this.attrs[k] = v; } };
   const otherSvg = { dataset: {}, attrs: {}, innerHTML: '<circle cx="12" cy="12" r="3"/>', setAttribute(k, v) { this.attrs[k] = v; } };
-  const ownButton = { textContent: '已归档的聊天', querySelector: (sel) => (sel === 'svg' ? gearSvg : null) };
+  const ownButton = { textContent: '会话档案', querySelector: (sel) => (sel === 'svg' ? gearSvg : null) };
   const otherButton = { textContent: '通用', querySelector: (sel) => (sel === 'svg' ? otherSvg : null) };
   mockDialogs = [{ querySelectorAll: (sel) => (sel === 'nav button' ? [ownButton, otherButton] : []) }];
   observers[0].cb();


### PR DESCRIPTION
## Summary
- rename the user-facing settings entry and page title to `会话档案` / `Session Archive`
- preserve the archive-success notice wording and technical plugin/package identifiers
- update bilingual README and architecture references
- add locale regression coverage for the new nav label and page title

## Verification
- `npm test` — 130/130 passing
- `node --check lib/client.js`
- `git diff --check`
