### PR TITLE
test: enforce public repository hygiene

### DIFF
--- a/scripts/check-repository-hygiene.mjs
+++ b/scripts/check-repository-hygiene.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { lstatSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootIndex = process.argv.indexOf('--root');
+if (rootIndex !== -1 && process.argv[rootIndex + 1] === undefined) {
+  console.error('--root requires a directory');
+  process.exit(2);
+}
+
+const defaultRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const root = resolve(rootIndex === -1 ? defaultRoot : process.argv[rootIndex + 1]);
+
+const forbiddenPrefixes = [
+  '.codegraph/',
+  '.release-work/',
+  '.screenshot-staging/',
+  '.superpowers/',
+  '.worktrees/',
+  'data/',
+  'docs/superpowers/',
+];
+
+const forbiddenExact = new Set([
+  '.anonymous-user-id',
+  '.credentials.yaml',
+  '.env',
+  '.npmrc',
+  'design-qa.md',
+]);
+
+const forbiddenSuffixes = ['.DS_Store', '.log', '.tgz', '.tmp'];
+const fragments = (...parts) => parts.join('');
+const localContent = [
+  ['macOS user path', fragments('/', 'Users', '/')],
+  ['private temporary path', fragments('/', 'private', '/', 'tmp', '/')],
+  ['macOS temporary path', fragments('/', 'var', '/', 'folders', '/')],
+  ['loopback IPv4 address', fragments('127', '.0', '.0', '.1')],
+  ['loopback host name', fragments('local', 'host')],
+  ['removed RTK command', fragments('r', 't', 'k', ' ')],
+  ['GitHub token command', fragments('gh', ' auth', ' token')],
+  ['GitHub token variable', fragments('GITHUB', '_TOKEN')],
+  ['npm credential text', fragments('npm', ' token')],
+];
+
+let tracked;
+try {
+  tracked = execFileSync('git', ['ls-files', '-z'], { cwd: root })
+    .toString('utf8')
+    .split('\0')
+    .filter(Boolean);
+} catch (error) {
+  console.error(`could not list tracked files in ${root}: ${error.message}`);
+  process.exit(2);
+}
+
+const violations = [];
+for (const path of tracked) {
+  const normalized = path.replaceAll('\\', '/');
+  if (forbiddenExact.has(normalized)
+    || forbiddenPrefixes.some((prefix) => normalized.startsWith(prefix))
+    || forbiddenSuffixes.some((suffix) => normalized.endsWith(suffix))) {
+    violations.push(`${normalized}: forbidden tracked path`);
+    continue;
+  }
+
+  const absolute = resolve(root, path);
+  let stat;
+  try { stat = lstatSync(absolute); }
+  catch { continue; }
+  if (!stat.isFile()) continue;
+
+  let bytes;
+  try { bytes = readFileSync(absolute); }
+  catch { continue; }
+  if (bytes.includes(0)) continue;
+
+  const lines = bytes.toString('utf8').split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    for (const [label, value] of localContent) {
+      if (lines[index].includes(value)) {
+        violations.push(`${normalized}:${index + 1}: ${label}`);
+      }
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('repository hygiene failed:');
+  for (const violation of violations) console.error(`  ${violation}`);
+  process.exit(1);
+}
+
+console.log(`repository hygiene: ${tracked.length} tracked files checked`);

--- a/test/repository-hygiene.test.mjs
+++ b/test/repository-hygiene.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = join(here, '..');
+const checker = join(repositoryRoot, 'scripts', 'check-repository-hygiene.mjs');
+
+function createRepository(files) {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-repository-hygiene-'));
+  execFileSync('git', ['init', '--quiet'], { cwd: root });
+  for (const [path, contents] of Object.entries(files)) {
+    const target = join(root, path);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, contents);
+  }
+  execFileSync('git', ['add', '--force', '--', ...Object.keys(files)], { cwd: root });
+  return root;
+}
+
+function runChecker(root) {
+  return spawnSync(process.execPath, [checker, '--root', root], {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+  });
+}
+
+function withRepository(files, assertion) {
+  const root = createRepository(files);
+  try { assertion(root); }
+  finally { rmSync(root, { recursive: true, force: true }); }
+}
+
+test('repository hygiene accepts tracked product and test files', () => {
+  withRepository({
+    'README.md': '# Plugin\n',
+    'lib/index.js': 'export const value = 1;\n',
+    'test/fixtures/synthetic.json': '{"synthetic":true}\n',
+  }, (root) => {
+    const result = runChecker(root);
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+test('repository hygiene rejects tracked internal process artifacts', () => {
+  const internalPath = ['docs', 'superpowers', 'plans', 'private.md'].join('/');
+  withRepository({ [internalPath]: '# Internal plan\n' }, (root) => {
+    const result = runChecker(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /docs\/superpowers\/plans\/private\.md/);
+  });
+});
+
+test('repository hygiene rejects tracked local machine paths', () => {
+  const localPath = ['', 'Users', 'example', 'private', 'capture.png'].join('/');
+  withRepository({ 'README.md': `temporary evidence: ${localPath}\n` }, (root) => {
+    const result = runChecker(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /README\.md:1/);
+  });
+});
+
+test('current repository passes the repository hygiene gate', () => {
+  const result = runChecker(repositoryRoot);
+  assert.equal(result.status, 0, result.stderr);
+});


### PR DESCRIPTION
## Summary

- add a repository hygiene checker that audits `git ls-files`
- fail on tracked internal AI/release artifacts, local data/index/worktree directories, credentials, logs, tarballs, and temporary files
- scan tracked text for macOS user/temp paths, localhost evidence, removed RTK commands, and token-handling text
- add integration tests against clean and deliberately contaminated temporary Git repositories

## TDD evidence

- RED 1: focused tests failed because the checker did not exist
- RED 2: minimal checker incorrectly allowed internal paths and local machine paths
- GREEN: all four focused hygiene tests pass

## Verification

- `npm test`: 155 passed, 0 failed
- `node scripts/check-repository-hygiene.mjs`: 71 tracked files checked
- `npm pack --dry-run --json`: unchanged 41-file package
- package SHA-1 and integrity remain unchanged; checker and tests are not packaged
- `git diff --check`: clean
