### PR TITLE
docs: add project maintenance and support policies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The maintainer reviews changes across the repository.
+* @Ultronen

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,8 @@
 name: 缺陷报告 / Bug report
 description: 报告能够复现的 dsh-archived-chats 缺陷
 title: "[Bug]: "
+labels:
+  - bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,8 @@
 name: 功能建议 / Feature request
 description: 建议一个面向已归档聊天管理的改进
 title: "[Feature]: "
+labels:
+  - enhancement
 body:
   - type: markdown
     attributes:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct / 贡献者公约行为准则
+
+本项目采用 Contributor Covenant 2.1。以下英文正文为执行依据；[官方翻译列表](https://www.contributor-covenant.org/translations/)提供其他语言版本。
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+For repository-specific incidents that can be described without sensitive details, contact the maintainer by mentioning [@Ultronen](https://github.com/Ultronen) in [Discussions](https://github.com/Ultronen/dsh-archived-chats/discussions). For a private report or platform-wide abuse, use GitHub's [Report abuse form](https://support.github.com/contact/report-abuse). Do not publish personal data or sensitive incident details in an Issue, Discussion, or pull request.
+
+All complaints will be reviewed and investigated promptly and fairly. Community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).

--- a/README.md
+++ b/README.md
@@ -116,7 +116,11 @@ The eight fixed screenshots below come from an isolated Simplified Chinese light
 | Architecture | [Maintainer architecture](docs/ARCHITECTURE.en.md) | [维护者架构](docs/ARCHITECTURE.md) |
 | Release history | [GitHub Releases](https://github.com/Ultronen/dsh-archived-chats/releases) | [GitHub Releases](https://github.com/Ultronen/dsh-archived-chats/releases) |
 
-See also [Security](SECURITY.md), [Contributing](CONTRIBUTING.md), and [Discussions](https://github.com/Ultronen/dsh-archived-chats/discussions).
+See also [Support](SUPPORT.md), [Security](SECURITY.md), [Contributing](CONTRIBUTING.md), [Code of Conduct](CODE_OF_CONDUCT.md), and [Discussions](https://github.com/Ultronen/dsh-archived-chats/discussions).
+
+## Project status
+
+Session Archive is actively maintained. The latest stable npm release receives fixes and security updates; older releases should be upgraded before reporting a problem. Reproducible bug reports and focused pull requests are welcome. Maintenance is performed as availability permits, so no fixed response or release schedule is promised.
 
 ## Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -116,7 +116,11 @@ dsh plugin --profile web update dsh-archived-chats
 | 架构说明 | [Maintainer architecture](docs/ARCHITECTURE.en.md) | [维护者架构](docs/ARCHITECTURE.md) |
 | 版本历史 | [GitHub Releases](https://github.com/Ultronen/dsh-archived-chats/releases) | [GitHub Releases](https://github.com/Ultronen/dsh-archived-chats/releases) |
 
-另见 [安全说明](SECURITY.md)、[贡献指南](CONTRIBUTING.md)和[问题交流](https://github.com/Ultronen/dsh-archived-chats/discussions)。
+另见 [支持说明](SUPPORT.md)、[安全说明](SECURITY.md)、[贡献指南](CONTRIBUTING.md)、[行为准则](CODE_OF_CONDUCT.md)和[问题交流](https://github.com/Ultronen/dsh-archived-chats/discussions)。
+
+## 项目状态
+
+Session Archive 目前处于积极维护状态。最新 npm 稳定版会接收缺陷修复与安全更新；报告问题前请先从旧版本升级。欢迎可复现的缺陷报告和目标集中的 Pull Request。项目按维护者的可用时间推进，不承诺固定响应或发布时间。
 
 ## 开发
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,22 @@
+# 支持 / Support
+
+感谢你使用 Session Archive。请选择最合适的入口，这样问题更容易被复现、讨论和跟进。
+
+| 需求 | 入口 |
+| --- | --- |
+| 安装、配置、使用问题 | [GitHub Discussions](https://github.com/Ultronen/dsh-archived-chats/discussions) |
+| 能稳定复现的缺陷 | [Bug report](https://github.com/Ultronen/dsh-archived-chats/issues/new?template=bug_report.yml) |
+| 功能建议 | [Feature request](https://github.com/Ultronen/dsh-archived-chats/issues/new?template=feature_request.yml) |
+| 安全漏洞或潜在数据泄露 | [Private security report](https://github.com/Ultronen/dsh-archived-chats/security/advisories/new) |
+
+提交前请先搜索已有 Issue 和 Discussion，并确认问题仍能在最新稳定版本复现。请提供插件版本、DeepSeek Harness 版本、操作系统、最小复现步骤和已经脱敏的诊断信息。
+
+不要提交真实聊天、附件、令牌、Cookie、私钥、完整用户目录路径或其他个人数据。涉及导入、恢复、回收站、永久删除或数据泄露的问题，如果可能属于安全漏洞，请使用私密报告入口。
+
+本项目由维护者在可用时间内维护，不承诺固定响应或发布时间。贡献代码前请先阅读 [CONTRIBUTING.md](CONTRIBUTING.md)；社区互动须遵守 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)。
+
+## English
+
+Use [Discussions](https://github.com/Ultronen/dsh-archived-chats/discussions) for installation and usage questions, the [bug report form](https://github.com/Ultronen/dsh-archived-chats/issues/new?template=bug_report.yml) for reproducible defects, and the [feature request form](https://github.com/Ultronen/dsh-archived-chats/issues/new?template=feature_request.yml) for proposals. Report vulnerabilities and possible data exposure through [private vulnerability reporting](https://github.com/Ultronen/dsh-archived-chats/security/advisories/new).
+
+Search existing reports first and reproduce against the latest stable release. Include versions, operating system, minimal steps, and sanitized diagnostics. Never submit real conversations, attachments, credentials, full home-directory paths, or personal data. Maintenance is performed as availability permits; no response or release schedule is guaranteed.


### PR DESCRIPTION
## Summary

- adopt Contributor Covenant 2.1 and add clear support routing
- define repository ownership and automatically label bug and feature reports
- document the active-maintenance policy in both English and Chinese READMEs

## User and compatibility impact

- User-visible change: clearer support, contribution, conduct, and maintenance expectations
- DeepSeek Harness compatibility: no runtime change
- Persistence/import/restore/deletion impact: none

## Verification

- [x] `npm test` — 201 passed
- [x] `npm pack --dry-run --json` — 37 expected files
- [x] Issue-form and workflow YAML parsed successfully
- [x] `git diff --check`
- [x] No UI change; screenshots are not applicable
- [x] English and Chinese READMEs updated together

## Safety and release boundaries

- [x] No local data, conversations, attachments, logs, credentials, or temporary files
- [x] Runtime and data-safety behavior are unchanged
- [x] Version, tags, npm publication, and marketplace metadata are unchanged