### PR TITLE
chore: declare minimum DSH version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-archived-chats",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-archived-chats",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-session": "^0.1.0-rc.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-archived-chats",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "DeepSeek Harness 会话档案：按工作区浏览和全文搜索归档聊天，原生只读预览对话、工具活动和已存储图片，管理标签备注与 ZIP 备份恢复；保留历史版本并恢复为副本，提供可撤销回收站、空间分账、保留策略和来源与分支。所有数据留在本机。 Session Archive for DeepSeek Harness: browse and full-text search archived chats; natively preview conversations, tool activity, and stored images read-only; manage tags, notes, and ZIP backup restore; retain local History with restore-as-copy, an undoable Recycle Bin, storage accounting, retention policies, and Origins & Branches. All data stays local.",
   "license": "MIT",
   "author": "Ultronen",
@@ -77,6 +77,9 @@
     "cordis.patch.yml"
   ],
   "dsh": {
+    "engines": {
+      "dsh": ">=0.1.0-rc.7"
+    },
     "bundle": {
       "patch": "./cordis.patch.yml"
     },

--- a/test/package.test.mjs
+++ b/test/package.test.mjs
@@ -7,7 +7,8 @@ import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
-const packageVersion = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version;
+const packageManifest = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+const packageVersion = packageManifest.version;
 const expectedScreenshots = [
   'assets/screenshots/preview-01.png',
   'assets/screenshots/preview-02.png',
@@ -18,6 +19,10 @@ const expectedScreenshots = [
   'assets/screenshots/preview-07.png',
   'assets/screenshots/preview-08.png',
 ];
+
+test('package declares the verified minimum DeepSeek Harness version', () => {
+  assert.equal(packageManifest.dsh?.engines?.dsh, '>=0.1.0-rc.7');
+});
 
 test('author-owned screenshot manifest keeps the eight stable market slots valid', () => {
   const declared = JSON.parse(readFileSync(join(root, 'screenshots.json'), 'utf8'));


### PR DESCRIPTION
## 变更摘要 / Summary

为社区插件索引登记补齐可机器读取的 DeepSeek Harness 最低兼容版本，并将补丁版本更新为 1.0.6。新增回归测试，防止后续发布遗漏 `dsh.engines.dsh`。

## 用户与兼容性影响 / User and compatibility impact

- 用户可见变化：无界面或运行时行为变化
- DeepSeek Harness 兼容性：明确声明 `>=0.1.0-rc.7`，与已使用的官方 session SDK 下限一致
- 持久化数据、导入/恢复或删除影响：无

## 验证 / Verification

- [x] `npm test`（两轮，202/202）
- [x] `npm pack --dry-run --json`
- [x] 从真实生成的 tarball 反查版本与 `dsh.engines.dsh`
- [x] 新增或更新了覆盖本次行为的测试
- [x] 界面变化不适用
- [x] 用户行为变化不适用

## 安全与发布边界 / Safety and release boundaries

- [x] 未提交本地数据、聊天内容、附件、日志、凭据或临时文件
- [x] 失败、回滚、并发和永久删除场景不适用，本次仅修改包元数据
- [x] 版本号修改由仓库维护者明确授权，用于发布 1.0.6