### PR TITLE
release: dsh-archived-chats 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,30 @@
 {
   "name": "dsh-archived-chats",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-archived-chats",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
         "fflate": "^0.8.3",
         "zip-stream": "^7.0.5"
       },
       "devDependencies": {
+        "@deepseek-ai/dsh-session": "0.1.0-rc.7",
         "typescript": "^5.9.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
+        "@deepseek-ai/dsh-session": ">=0.1.0-rc.7 <0.1.1-0 || >=0.1.1-rc.1 <0.1.2-0 || >=0.1.2-alpha.1 <0.2.0-0",
         "react": "^18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-session": {
+          "optional": true
+        }
       }
     },
     "node_modules/@deepseek-ai/cordis": {
@@ -58,6 +64,7 @@
       "version": "0.1.0-rc.7",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.0-rc.7.tgz",
       "integrity": "sha512-rsR/xVNOGIig8gXxhrKnkd6YD7aYliGtA/e7b4DlPawMpLhsItAh0HQ832n8LJn1aGZxKf68y9PRgzfljsveOQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -70,6 +77,7 @@
       "version": "0.1.0-rc.7",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.0-rc.7.tgz",
       "integrity": "sha512-P7+w0fN40yXXQkV360p6jQi63pcl68OOWebNGN5gf8w8sguvni2mA1cU8RLZzDkRNFSZD+BCw3D4uWYM+hhh7A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -81,6 +89,7 @@
       "version": "0.1.0-rc.7",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.0-rc.7.tgz",
       "integrity": "sha512-PnO1F4aZGUmqZPyuPJpBUfQ4DZmjCGCNGr0yuN2iURTP/e6h0kGnTNTYgR2NqMvAtpP66WNiHhvH2LMqumk1+A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -94,6 +103,7 @@
       "version": "0.1.0-rc.7",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.0-rc.7.tgz",
       "integrity": "sha512-VaB9kQ8XOA+R5jtsWf92QMc1WpaatEAFUvQePGUYrzQ7Z86b9VhQQzmchh5VmknT4oRSSdn0re5tReCvfcYNXQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -111,6 +121,7 @@
       "version": "0.1.0-rc.7",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.0-rc.7.tgz",
       "integrity": "sha512-8gn+sANXhpv+9egbNwq49/uI3XhbmB33obo9yMyzyzruan3zFoxeH4UV54jTC2hjbu8gFNPsyNam9AAtRV8/Cg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -122,6 +133,7 @@
       "version": "0.1.0-rc.7",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.0-rc.7.tgz",
       "integrity": "sha512-02WVTkqIH+TyDL7dhMN3Hm+qcTEdhD0fVDC0aIAyND2fBdXj3CagEXXvpmt3mzwWfKwOTGL1RdxtC6pMA4Bl1A==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
@@ -136,6 +148,7 @@
       "version": "0.1.0-rc.7",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.0-rc.7.tgz",
       "integrity": "sha512-Ufl9G7zP7Tky/zkXscavEiolEfAwutfbPeLb5sUU/tPQlDykhh1NwGrarNJ11fdR723zmA/3co4LgxtDtWCOEQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -147,6 +160,7 @@
       "version": "0.1.0-rc.7",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.0-rc.7.tgz",
       "integrity": "sha512-R7qdvaRRHbz5xijoVOxueeBB/VT0eDzuQNQN4iNEBUbI/L9xG9bZutktTQlgrIlBSn1sPH4pLqiCiM6ErQPTaQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -158,6 +172,7 @@
       "version": "3.18.1",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.1.tgz",
       "integrity": "sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-archived-chats",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "DeepSeek Harness 会话档案：按工作区浏览和全文搜索归档聊天，原生只读预览对话、工具活动和已存储图片，管理标签备注与 ZIP 备份恢复；保留历史版本并恢复为副本，提供可撤销回收站、空间分账、保留策略和来源与分支。所有数据留在本机。 Session Archive for DeepSeek Harness: browse and full-text search archived chats; natively preview conversations, tool activity, and stored images read-only; manage tags, notes, and ZIP backup restore; retain local History with restore-as-copy, an undoable Recycle Bin, storage accounting, retention policies, and Origins & Branches. All data stays local.",
   "license": "MIT",
   "author": "Ultronen",
@@ -85,7 +85,6 @@
     },
     "client": {
       "inject": [
-        "@deepseek-ai/dsh-client-runtime",
         "@deepseek-ai/dsh-client-locale"
       ],
       "platform": "web",
@@ -94,14 +93,20 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-session": ">=0.1.0-rc.7 <0.1.1-0 || >=0.1.1-rc.1 <0.1.2-0 || >=0.1.2-alpha.1 <0.2.0-0",
     "react": "^18.2.0"
   },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/dsh-session": {
+      "optional": true
+    }
+  },
   "dependencies": {
-    "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
     "fflate": "^0.8.3",
     "zip-stream": "^7.0.5"
   },
   "devDependencies": {
+    "@deepseek-ai/dsh-session": "0.1.0-rc.7",
     "typescript": "^5.9.3"
   }
 }

--- a/test/package.test.mjs
+++ b/test/package.test.mjs
@@ -24,6 +24,22 @@ test('package declares the verified minimum DeepSeek Harness version', () => {
   assert.equal(packageManifest.dsh?.engines?.dsh, '>=0.1.0-rc.7');
 });
 
+test('client bootstrap stays compatible with stable and alpha.2 through the locale dependency closure', () => {
+  assert.deepEqual(
+    packageManifest.dsh?.client?.inject,
+    ['@deepseek-ai/dsh-client-locale'],
+  );
+});
+
+test('host session API follows the DSH-provided stable or alpha package instead of bundling an old core', () => {
+  assert.equal(packageManifest.dependencies?.['@deepseek-ai/dsh-session'], undefined);
+  assert.equal(
+    packageManifest.peerDependencies?.['@deepseek-ai/dsh-session'],
+    '>=0.1.0-rc.7 <0.1.1-0 || >=0.1.1-rc.1 <0.1.2-0 || >=0.1.2-alpha.1 <0.2.0-0',
+  );
+  assert.equal(packageManifest.peerDependenciesMeta?.['@deepseek-ai/dsh-session']?.optional, true);
+});
+
 test('author-owned screenshot manifest keeps the eight stable market slots valid', () => {
   const declared = JSON.parse(readFileSync(join(root, 'screenshots.json'), 'utf8'));
 


### PR DESCRIPTION
## 关联 Issue / Linked issue

Maintainer-directed compatibility release; no linked issue.

- [x] 维护者已确认需求范围和我的认领，或我已在上方说明为何不适用

## 变更摘要 / Summary

- make client bootstrap compatible with stable DSH and 0.1.2-alpha.2 through the locale dependency closure
- consume the Host-provided dsh-session package instead of bundling an older core copy
- add package-metadata regression coverage and prepare version 1.0.7

## 用户与兼容性影响 / User and compatibility impact

- 用户可见变化：无界面或功能变化
- DeepSeek Harness 兼容性：保持稳定版支持，并新增 0.1.2-alpha.2 启动兼容
- 持久化数据、导入/恢复或删除影响：无

## 验证 / Verification

- [x] npm test（204 passed）
- [x] npm pack --dry-run --json
- [x] 实现满足维护者确认的兼容性范围
- [x] 新增或更新了覆盖本次行为的测试
- [x] 无界面变化，截图不适用
- [x] 无用户行为变化，双语用户文档不需要更新

## 安全与发布边界 / Safety and release boundaries

- [x] 未提交本地数据、聊天内容、附件、日志、凭据或临时文件
- [x] 不涉及失败、回滚、并发或永久删除流程
- [x] 版本号由维护者明确更新为 1.0.7；标签、npm 发布和市场更新将在 PR 合并且 CI 通过后执行