### PR TITLE
docs: keep release workflow maintainer-only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,10 +63,6 @@ PR 应保持单一目的，并说明用户可见变化、兼容性影响、数�
 
 不得提交本地插件数据、数据库、聊天内容、附件、日志、访问令牌、`.DS_Store` 或测试临时文件。对导入、恢复、回收站和永久删除流程的改动必须包含失败与回滚场景测试。
 
-## 发布命名规则
-
-GitHub Release 标题必须与发布 tag 完全一致，例如 tag 为 `v1.0.2` 时标题只能是 `v1.0.2`，不要添加包名或其他前缀。产品名称和版本说明可以写在 Release body 中。
-
 ## Pull request checklist
 
 1. 完整阅读并遵守本贡献指南。
@@ -112,5 +108,3 @@ Anyone may propose a feature, but opening an issue starts review; it does not ad
 5. **Delivery:** use `Closes #number` and meet the confirmed acceptance criteria, tests, bilingual documentation, and safety requirements. An issue is complete only when its PR is merged; review may narrow the scope or move follow-up work into separate issues.
 
 Typos, small documentation fixes, and changes directly requested by the maintainer may skip formal claiming. Other user-visible behavior and all changes involving persisted data, import or restore, the Recycle Bin, or permanent deletion require an issue and maintainer confirmation first.
-
-GitHub Release titles must exactly match their tags (for example, `v1.0.2`); do not prefix them with the package name. Put product naming and release descriptions in the release body instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@
 - `short-description` 使用简短、小写的英文，单词之间用连字符，例如 `feat/archive-filter` 或 `fix/import-timeout`。分支名不必重复 Issue 编号。
 - 提交信息和 PR 标题使用 Conventional Commits 格式 `<type>(<optional-scope>): <description>`，描述使用现在时命令语气并保持在 72 个字符内，例如 `fix(import): prevent restore timeout`。
 - 一个分支和 PR 只处理一项逻辑改动；Issue 关联写在 PR 描述中，例如 `Closes #42`。
-- `release/*` 分支、版本号、Tag、npm 发布和插件市场更新仅由维护者处理。安全漏洞不得使用公开分支或 PR，请按 [SECURITY.md](SECURITY.md) 私密报告。
+- `release/*` 分支仅由维护者使用。安全漏洞不得使用公开分支或 PR，请按 [SECURITY.md](SECURITY.md) 私密报告。
 
 ## 贡献范围与维护者控制文件
 
@@ -59,7 +59,7 @@ npm test
 npm pack --dry-run --json
 ```
 
-PR 应保持单一目的，并说明用户可见变化、兼容性影响、数据安全影响和验证结果。界面变化应附截图。除非维护者明确要求，不要修改版本号、创建标签、发布 npm 包或更新插件市场。
+PR 应保持单一目的，并说明用户可见变化、兼容性影响、数据安全影响和验证结果。界面变化应附截图。
 
 不得提交本地插件数据、数据库、聊天内容、附件、日志、访问令牌、`.DS_Store` 或测试临时文件。对导入、恢复、回收站和永久删除流程的改动必须包含失败与回滚场景测试。
 
@@ -75,7 +75,7 @@ PR 应保持单一目的，并说明用户可见变化、兼容性影响、数�
 
 ## English summary
 
-Use Discussions for questions, Issues for reproducible bugs, and private vulnerability reporting for security problems. Keep pull requests focused, add tests, update both language documents when user behavior changes, and run `npm test` plus `npm pack --dry-run --json`. Never commit local plugin data, conversations, attachments, credentials, logs, or temporary files. Versioning, npm publication, tags, releases, and marketplace updates are maintainer-only unless explicitly requested.
+Use Discussions for questions, Issues for reproducible bugs, and private vulnerability reporting for security problems. Keep pull requests focused, add tests, update both language documents when user behavior changes, and run `npm test` plus `npm pack --dry-run --json`. Never commit local plugin data, conversations, attachments, credentials, logs, or temporary files.
 
 ### Branch, commit, and pull request naming
 
@@ -83,7 +83,7 @@ Use Discussions for questions, Issues for reproducible bugs, and private vulnera
 - Write the short description in concise lowercase English with hyphens, such as `feat/archive-filter` or `fix/import-timeout`. The issue number does not need to be repeated in the branch name.
 - Use Conventional Commits for commit messages and PR titles: `<type>(<optional-scope>): <description>`. Use imperative present tense and keep the title within 72 characters, for example `fix(import): prevent restore timeout`.
 - Keep one logical change per branch and PR. Link the issue in the PR description, for example `Closes #42`.
-- `release/*` branches, versions, tags, npm publication, and marketplace updates are maintainer-only. Never disclose a vulnerability in a public branch or PR; follow [SECURITY.md](SECURITY.md) instead.
+- `release/*` branches are maintainer-only. Never disclose a vulnerability in a public branch or PR; follow [SECURITY.md](SECURITY.md) instead.
 
 ### Contribution scope and maintainer-controlled files
 


### PR DESCRIPTION
Summary:
- remove maintainer-only GitHub Release naming instructions from the public contribution guide
- remove repeated release and marketplace wording from contributor workflow sections
- retain one clear maintainer-controlled boundary for versions, releases, marketplace entries, and official assets
- keep the pull request confirmation that prevents accidental release changes

Validation:
- npm test
- npm pack --dry-run --json
- git diff --check