### PR TITLE
test(package): verify public export map

### DIFF
--- a/test/package.test.mjs
+++ b/test/package.test.mjs
@@ -40,6 +40,18 @@ test('host session API follows the DSH-provided stable or alpha package instead 
   assert.equal(packageManifest.peerDependenciesMeta?.['@deepseek-ai/dsh-session']?.optional, true);
 });
 
+test('public runtime exports stay paired with their TypeScript declarations', () => {
+  for (const [specifier, runtime, declarations] of [
+    ['.', './lib/index.js', './lib/types/index.d.ts'],
+    ['./client', './lib/client.js', './lib/types/client/index.d.ts'],
+  ]) {
+    assert.deepEqual(packageManifest.exports?.[specifier], {
+      types: declarations,
+      default: runtime,
+    });
+  }
+});
+
 test('author-owned screenshot manifest keeps the eight stable market slots valid', () => {
   const declared = JSON.parse(readFileSync(join(root, 'screenshots.json'), 'utf8'));
 


### PR DESCRIPTION
## Linked issue

Not applicable — this is a test-only maintenance change with no product behavior change.

## Summary

- Add a package contract regression test for the public Host and client exports.
- Verify that each JavaScript entry point remains paired with its TypeScript declaration entry.

## User and compatibility impact

- User-visible changes: None.
- DeepSeek Harness compatibility: Unchanged.
- Persisted data, import/restore, or deletion impact: None.

## Verification

- [x] `npm test` (205 tests passed)
- [x] `npm pack --dry-run --json`
- [x] Added coverage for the changed test contract
- [x] No UI change; screenshots are not applicable
- [x] No user behavior change; bilingual documentation is not applicable

## Safety and release boundaries

- [x] No local data, conversations, attachments, logs, credentials, or temporary files committed
- [x] Failure, rollback, concurrency, and permanent deletion scenarios are not applicable
- [x] Only `test/package.test.mjs` is changed
- [x] No version, tag, release, workflow, marketplace, or maintainer-controlled file changes
